### PR TITLE
Entities: Refactored hash(), equals() and toString()

### DIFF
--- a/fleet-management/src/main/java/cz/fi/muni/pa165/entity/Employee.java
+++ b/fleet-management/src/main/java/cz/fi/muni/pa165/entity/Employee.java
@@ -43,4 +43,29 @@ public class Employee {
     public void setSurname(String surname) {
         this.surname = surname;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Employee employee = (Employee) o;
+
+        return id != null ? id.equals(employee.id) : employee.id == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        return id != null ? id.hashCode() : 0;
+    }
+
+    @Override
+    public String toString() {
+        return "Employee{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                ", surname='" + surname + '\'' +
+                '}';
+    }
 }

--- a/fleet-management/src/main/java/cz/fi/muni/pa165/entity/Inspection.java
+++ b/fleet-management/src/main/java/cz/fi/muni/pa165/entity/Inspection.java
@@ -32,4 +32,28 @@ public class Inspection {
     public void setPerformedAt(Date performedAt){
         this.performedAt = performedAt;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Inspection that = (Inspection) o;
+
+        return id != null ? id.equals(that.id) : that.id == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        return id != null ? id.hashCode() : 0;
+    }
+
+    @Override
+    public String toString() {
+        return "Inspection{" +
+                "id=" + id +
+                ", performedAt=" + performedAt +
+                '}';
+    }
 }

--- a/fleet-management/src/main/java/cz/fi/muni/pa165/entity/InspectionInterval.java
+++ b/fleet-management/src/main/java/cz/fi/muni/pa165/entity/InspectionInterval.java
@@ -22,29 +22,53 @@ public class InspectionInterval {
     @Column(nullable = false)
     private int days;
 
-    public InspectionInterval(String name, int interval){
+    public InspectionInterval(String name, int interval) {
         this.name = name;
         this.days = interval;
     }
 
-    public Long getId(){
+    public Long getId() {
         return this.id;
     }
 
-    public String getName(){
+    public String getName() {
         return this.name;
     }
 
-    public int getDays(){
+    public int getDays() {
         return this.days;
     }
 
-    public void setName(String name){
+    public void setName(String name) {
         this.name = name;
     }
 
-    public void setDays(int days){
+    public void setDays(int days) {
         this.days = days;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        InspectionInterval that = (InspectionInterval) o;
+
+        return id != null ? id.equals(that.id) : that.id == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        return id != null ? id.hashCode() : 0;
+    }
+
+    @Override
+    public String toString() {
+        return "InspectionInterval{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                ", days=" + days +
+                '}';
+    }
 }

--- a/fleet-management/src/main/java/cz/fi/muni/pa165/entity/Journey.java
+++ b/fleet-management/src/main/java/cz/fi/muni/pa165/entity/Journey.java
@@ -32,8 +32,8 @@ public class Journey {
      * Creates entity in initial phase where vehicle is borrowed.
      *
      * @param borrowedAt Date, when vehicle was borrowed.
-     * @param vehicle Vehicle which was borrowed.
-     * @param employee Employee who borrowed a vehicle.
+     * @param vehicle    Vehicle which was borrowed.
+     * @param employee   Employee who borrowed a vehicle.
      */
     public Journey(Date borrowedAt, Vehicle vehicle, Employee employee) {
         this.borrowedAt = borrowedAt;
@@ -45,7 +45,7 @@ public class Journey {
      * Updated entity to final phase where vehicle is returned.
      *
      * @param returnedAt Date, when vehicle was returned.
-     * @param distance Distance driven with this vehicle during the journey in kilometres.
+     * @param distance   Distance driven with this vehicle during the journey in kilometres.
      */
     public void returnVehicle(Date returnedAt, Float distance) {
         this.returnedAt = returnedAt;
@@ -105,24 +105,13 @@ public class Journey {
 
         Journey journey = (Journey) o;
 
-        if (!id.equals(journey.id)) return false;
-        if (!distance.equals(journey.distance)) return false;
-        if (!borrowedAt.equals(journey.borrowedAt)) return false;
-        if (!returnedAt.equals(journey.returnedAt)) return false;
-        if (!vehicle.equals(journey.vehicle)) return false;
-        return employee.equals(journey.employee);
+        return id != null ? id.equals(journey.id) : journey.id == null;
 
     }
 
     @Override
     public int hashCode() {
-        int result = id.hashCode();
-        result = 31 * result + distance.hashCode();
-        result = 31 * result + borrowedAt.hashCode();
-        result = 31 * result + returnedAt.hashCode();
-        result = 31 * result + vehicle.hashCode();
-        result = 31 * result + employee.hashCode();
-        return result;
+        return id != null ? id.hashCode() : 0;
     }
 
     @Override

--- a/fleet-management/src/main/java/cz/fi/muni/pa165/entity/Vehicle.java
+++ b/fleet-management/src/main/java/cz/fi/muni/pa165/entity/Vehicle.java
@@ -16,39 +16,39 @@ public class Vehicle {
     /**
      * Vehicle registration plate number (SPZ).
      */
-    @Column(nullable=false, unique=true)
+    @Column(nullable = false, unique = true)
     private String vrp;
 
     /**
      * Car producer and model.
      */
-    @Column(nullable=false)
+    @Column(nullable = false)
     private String type;
 
-    @Column(nullable=false)
+    @Column(nullable = false)
     private Year productionYear;
 
-    @Column(nullable=false)
+    @Column(nullable = false)
     private String engineType;
 
-    @Column(nullable=false, unique=true)
+    @Column(nullable = false, unique = true)
     private String vin;
 
     /**
      * Number od driven kilometres when car was added to the catalogue.
      */
-    @Column(nullable=false)
+    @Column(nullable = false)
     private Long initialKilometrage;
 
     @ManyToOne
     private VehicleCategory vehicleCategory;
 
     /**
-     * @param vrp Vehicle VRP.
-     * @param type Mane of the manufacturer name.
-     * @param productionYear Year when vehicle was manufactured.
-     * @param engineType Type of the engine.
-     * @param vin Vehicle VIN.
+     * @param vrp                Vehicle VRP.
+     * @param type               Mane of the manufacturer name.
+     * @param productionYear     Year when vehicle was manufactured.
+     * @param engineType         Type of the engine.
+     * @param vin                Vehicle VIN.
      * @param initialKilometrage The driven distance when vehicle was added to the catalogue. In kilometres.
      */
     public Vehicle(String vrp, String type, Year productionYear, String engineType, String vin, Long initialKilometrage) {
@@ -130,20 +130,17 @@ public class Vehicle {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || !(o instanceof Vehicle)) return false;
+        if (o == null || getClass() != o.getClass()) return false;
 
         Vehicle vehicle = (Vehicle) o;
 
-        if (!getVrp().equals(vehicle.getVrp())) return false;
-        return getVin().equals(vehicle.getVin());
+        return id != null ? id.equals(vehicle.id) : vehicle.id == null;
 
     }
 
     @Override
     public int hashCode() {
-        int result = getVrp().hashCode();
-        result = 31 * result + getVin().hashCode();
-        return result;
+        return id != null ? id.hashCode() : 0;
     }
 
     @Override
@@ -152,10 +149,11 @@ public class Vehicle {
                 "id=" + id +
                 ", vrp='" + vrp + '\'' +
                 ", type='" + type + '\'' +
-                ", productionYear='" + productionYear + '\'' +
+                ", productionYear=" + productionYear +
                 ", engineType='" + engineType + '\'' +
                 ", vin='" + vin + '\'' +
                 ", initialKilometrage=" + initialKilometrage +
+                ", vehicleCategory=" + vehicleCategory +
                 '}';
     }
 }

--- a/fleet-management/src/main/java/cz/fi/muni/pa165/entity/VehicleCategory.java
+++ b/fleet-management/src/main/java/cz/fi/muni/pa165/entity/VehicleCategory.java
@@ -16,11 +16,11 @@ public class VehicleCategory {
     private Long id;
 
     @NotNull
-    @Column(nullable=false, unique=true)
+    @Column(nullable = false, unique = true)
     private String name;
 
     @OneToMany(mappedBy = "vehicleCategory")
-    private Set<Vehicle> vehicles = new HashSet<Vehicle>();
+    private Set<Vehicle> vehicles = new HashSet<>();
 
     public Long getId() {
         return id;
@@ -50,20 +50,21 @@ public class VehicleCategory {
         vehicles.add(vehicle);
     }
 
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || !(o instanceof VehicleCategory)) return false;
+        if (o == null || getClass() != o.getClass()) return false;
 
         VehicleCategory that = (VehicleCategory) o;
 
-        return getName().equals(that.getName());
+        return id != null ? id.equals(that.id) : that.id == null;
 
     }
 
     @Override
     public int hashCode() {
-        return getName().hashCode();
+        return id != null ? id.hashCode() : 0;
     }
 
     @Override
@@ -71,6 +72,7 @@ public class VehicleCategory {
         return "VehicleCategory{" +
                 "id=" + id +
                 ", name='" + name + '\'' +
+                ", vehicles=" + vehicles +
                 '}';
     }
 }


### PR DESCRIPTION
I added missing `hashCode()`, `equals()` and `toString()` methods everywhere where they have been missing and updated `equals()` method, co it compares only `class` and `id`, since comparing other fields is unnecessary because of very definition of entity.