### PR TITLE
Equals hashcode fixing

### DIFF
--- a/fleet-management/fleet-management.iml
+++ b/fleet-management/fleet-management.iml
@@ -10,53 +10,8 @@
       <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
-    <orderEntry type="jdk" jdkName="1.8" jdkType="JavaSDK" />
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="Maven: org.hibernate.javax.persistence:hibernate-jpa-2.1-api:1.0.0.Final" level="project" />
-    <orderEntry type="library" name="Maven: org.hibernate:hibernate-validator:5.2.4.Final" level="project" />
-    <orderEntry type="library" name="Maven: org.jboss.logging:jboss-logging:3.2.1.Final" level="project" />
-    <orderEntry type="library" name="Maven: com.fasterxml:classmate:1.1.0" level="project" />
-    <orderEntry type="library" name="Maven: javax.persistence:persistence-api:1.0.2" level="project" />
-    <orderEntry type="library" name="Maven: javax.validation:validation-api:1.1.0.Final" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.mockito:mockito-all:1.10.19" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.springframework:spring-test:4.0.6.RELEASE" level="project" />
-    <orderEntry type="library" name="Maven: org.springframework:spring-core:4.0.6.RELEASE" level="project" />
-    <orderEntry type="library" name="Maven: commons-logging:commons-logging:1.1.3" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.testng:testng:6.8.8" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.beanshell:bsh:2.0b4" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: com.beust:jcommander:1.27" level="project" />
-    <orderEntry type="library" name="Maven: com.sun.xml.bind:jaxb-impl:2.2.7" level="project" />
-    <orderEntry type="library" name="Maven: com.sun.xml.bind:jaxb-core:2.2.7" level="project" />
-    <orderEntry type="library" name="Maven: javax.xml.bind:jaxb-api:2.2.7" level="project" />
-    <orderEntry type="library" name="Maven: com.sun.istack:istack-commons-runtime:2.16" level="project" />
-    <orderEntry type="library" name="Maven: com.sun.xml.fastinfoset:FastInfoset:1.2.12" level="project" />
-    <orderEntry type="library" name="Maven: javax.xml.bind:jsr173_api:1.0" level="project" />
-    <orderEntry type="library" name="Maven: org.springframework:spring-tx:4.0.6.RELEASE" level="project" />
-    <orderEntry type="library" name="Maven: org.springframework:spring-beans:4.0.6.RELEASE" level="project" />
-    <orderEntry type="library" name="Maven: org.springframework.data:spring-data-jpa:1.6.1.RELEASE" level="project" />
-    <orderEntry type="library" name="Maven: org.springframework.data:spring-data-commons:1.8.1.RELEASE" level="project" />
-    <orderEntry type="library" name="Maven: org.springframework:spring-orm:3.2.9.RELEASE" level="project" />
-    <orderEntry type="library" name="Maven: org.springframework:spring-jdbc:3.2.9.RELEASE" level="project" />
-    <orderEntry type="library" name="Maven: org.springframework:spring-context:3.2.9.RELEASE" level="project" />
-    <orderEntry type="library" name="Maven: org.springframework:spring-expression:3.2.9.RELEASE" level="project" />
-    <orderEntry type="library" name="Maven: org.springframework:spring-aop:3.2.9.RELEASE" level="project" />
-    <orderEntry type="library" name="Maven: aopalliance:aopalliance:1.0" level="project" />
-    <orderEntry type="library" name="Maven: org.aspectj:aspectjrt:1.8.0" level="project" />
-    <orderEntry type="library" name="Maven: org.slf4j:slf4j-api:1.7.7" level="project" />
-    <orderEntry type="library" scope="RUNTIME" name="Maven: org.slf4j:jcl-over-slf4j:1.7.7" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.hibernate:hibernate-entitymanager:4.3.5.Final" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.jboss.logging:jboss-logging-annotations:1.2.0.Beta1" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.hibernate:hibernate-core:4.3.5.Final" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: antlr:antlr:2.7.7" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.jboss:jandex:1.1.0.Final" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: dom4j:dom4j:1.6.1" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: xml-apis:xml-apis:1.0.b2" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.hibernate.common:hibernate-commons-annotations:4.0.4.Final" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.jboss.spec.javax.transaction:jboss-transaction-api_1.2_spec:1.0.0.Final" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.javassist:javassist:3.18.1-GA" level="project" />
-    <orderEntry type="library" name="Maven: javax.el:javax.el-api:2.2.4" level="project" />
-    <orderEntry type="library" name="Maven: org.glassfish.web:javax.el:2.2.4" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.derby:derby:10.12.1.1" level="project" />
     <orderEntry type="library" name="Maven: org.hibernate.javax.persistence:hibernate-jpa-2.1-api:1.0.0.Final" level="project" />
     <orderEntry type="library" name="Maven: org.hibernate:hibernate-validator:5.2.4.Final" level="project" />
     <orderEntry type="library" name="Maven: org.jboss.logging:jboss-logging:3.2.1.Final" level="project" />

--- a/fleet-management/src/main/java/cz/fi/muni/pa165/entity/Employee.java
+++ b/fleet-management/src/main/java/cz/fi/muni/pa165/entity/Employee.java
@@ -47,17 +47,20 @@ public class Employee {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (o == null || (!(o instanceof Employee))) return false;
 
         Employee employee = (Employee) o;
 
-        return id != null ? id.equals(employee.id) : employee.id == null;
+        if (name != null ? !name.equals(employee.getName()) : employee.getName() != null) return false;
+        return surname != null ? surname.equals(employee.getSurname()) : employee.getSurname() == null;
 
     }
 
     @Override
     public int hashCode() {
-        return id != null ? id.hashCode() : 0;
+        int result = name != null ? name.hashCode() : 0;
+        result = 31 * result + (surname != null ? surname.hashCode() : 0);
+        return result;
     }
 
     @Override

--- a/fleet-management/src/main/java/cz/fi/muni/pa165/entity/Employee.java
+++ b/fleet-management/src/main/java/cz/fi/muni/pa165/entity/Employee.java
@@ -19,6 +19,12 @@ public class Employee {
     @Column(nullable=false)
     private String surname;
 
+    /**
+     * Initialize new Employee object. For serialization uses.
+     */
+    public Employee() {
+    }
+
     public Employee(String name, String surname) {
         this.name = name;
         this.surname = surname;

--- a/fleet-management/src/main/java/cz/fi/muni/pa165/entity/Employee.java
+++ b/fleet-management/src/main/java/cz/fi/muni/pa165/entity/Employee.java
@@ -25,6 +25,10 @@ public class Employee {
     public Employee() {
     }
 
+    /**
+     * @param name    name of the Employee
+     * @param surname surname of the Employee
+     */
     public Employee(String name, String surname) {
         this.name = name;
         this.surname = surname;

--- a/fleet-management/src/main/java/cz/fi/muni/pa165/entity/Employee.java
+++ b/fleet-management/src/main/java/cz/fi/muni/pa165/entity/Employee.java
@@ -20,9 +20,10 @@ public class Employee {
     private String surname;
 
     /**
-     * Initialize new Employee object. For serialization uses.
+     * All persistent classes must have a default constructor (which can be non-public)
+     * so that Hibernate can instantiate them using Constructor.newInstance().
      */
-    public Employee() {
+    protected Employee() {
     }
 
     /**

--- a/fleet-management/src/main/java/cz/fi/muni/pa165/entity/Inspection.java
+++ b/fleet-management/src/main/java/cz/fi/muni/pa165/entity/Inspection.java
@@ -45,17 +45,17 @@ public class Inspection {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (o == null || (!(o instanceof Inspection))) return false;
 
         Inspection that = (Inspection) o;
 
-        return id != null ? id.equals(that.id) : that.id == null;
+        return performedAt != null ? performedAt.equals(that.getPerformedAt()) : that.getPerformedAt() == null;
 
     }
 
     @Override
     public int hashCode() {
-        return id != null ? id.hashCode() : 0;
+        return performedAt != null ? performedAt.hashCode() : 0;
     }
 
     @Override

--- a/fleet-management/src/main/java/cz/fi/muni/pa165/entity/Inspection.java
+++ b/fleet-management/src/main/java/cz/fi/muni/pa165/entity/Inspection.java
@@ -18,9 +18,10 @@ public class Inspection {
     private Date performedAt;
 
     /**
-     * Initialize new Inspection object. For serialization uses.
+     * All persistent classes must have a default constructor (which can be non-public)
+     * so that Hibernate can instantiate them using Constructor.newInstance().
      */
-    public Inspection(){}
+    protected Inspection(){}
 
     /**
      * Initializes new Inspection object.

--- a/fleet-management/src/main/java/cz/fi/muni/pa165/entity/InspectionInterval.java
+++ b/fleet-management/src/main/java/cz/fi/muni/pa165/entity/InspectionInterval.java
@@ -60,17 +60,20 @@ public class InspectionInterval {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (o == null || (!(o instanceof InspectionInterval))) return false;
 
         InspectionInterval that = (InspectionInterval) o;
 
-        return id != null ? id.equals(that.id) : that.id == null;
+        if (days != that.getDays()) return false;
+        return name != null ? name.equals(that.getName()) : that.getName() == null;
 
     }
 
     @Override
     public int hashCode() {
-        return id != null ? id.hashCode() : 0;
+        int result = name != null ? name.hashCode() : 0;
+        result = 31 * result + days;
+        return result;
     }
 
     @Override

--- a/fleet-management/src/main/java/cz/fi/muni/pa165/entity/InspectionInterval.java
+++ b/fleet-management/src/main/java/cz/fi/muni/pa165/entity/InspectionInterval.java
@@ -25,7 +25,8 @@ public class InspectionInterval {
     /**
      * Initialize new Inspection object. For serialization uses.
      */
-    public InspectionInterval(){}
+    public InspectionInterval(){
+    }
 
     /**
      * Initializes new InspectionInterval object

--- a/fleet-management/src/main/java/cz/fi/muni/pa165/entity/InspectionInterval.java
+++ b/fleet-management/src/main/java/cz/fi/muni/pa165/entity/InspectionInterval.java
@@ -23,9 +23,10 @@ public class InspectionInterval {
     private int days;
 
     /**
-     * Initialize new Inspection object. For serialization uses.
+     * All persistent classes must have a default constructor (which can be non-public)
+     * so that Hibernate can instantiate them using Constructor.newInstance().
      */
-    public InspectionInterval(){
+    protected InspectionInterval(){
     }
 
     /**

--- a/fleet-management/src/main/java/cz/fi/muni/pa165/entity/Journey.java
+++ b/fleet-management/src/main/java/cz/fi/muni/pa165/entity/Journey.java
@@ -101,17 +101,22 @@ public class Journey {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (o == null || (!(o instanceof Journey))) return false;
 
         Journey journey = (Journey) o;
 
-        return id != null ? id.equals(journey.id) : journey.id == null;
+        if (distance != null ? !distance.equals(journey.getDistance()) : journey.getDistance() != null) return false;
+        if (borrowedAt != null ? !borrowedAt.equals(journey.getBorrowedAt()) : journey.getBorrowedAt() != null) return false;
+        return returnedAt != null ? returnedAt.equals(journey.getReturnedAt()) : journey.getReturnedAt()== null;
 
     }
 
     @Override
     public int hashCode() {
-        return id != null ? id.hashCode() : 0;
+        int result = distance != null ? distance.hashCode() : 0;
+        result = 31 * result + (borrowedAt != null ? borrowedAt.hashCode() : 0);
+        result = 31 * result + (returnedAt != null ? returnedAt.hashCode() : 0);
+        return result;
     }
 
     @Override

--- a/fleet-management/src/main/java/cz/fi/muni/pa165/entity/Journey.java
+++ b/fleet-management/src/main/java/cz/fi/muni/pa165/entity/Journey.java
@@ -29,6 +29,12 @@ public class Journey {
     private Employee employee;
 
     /**
+     * Initialize new Journey object. For serialization uses.
+     */
+    public Journey() {
+    }
+
+    /**
      * Creates entity in initial phase where vehicle is borrowed.
      *
      * @param borrowedAt Date, when vehicle was borrowed.

--- a/fleet-management/src/main/java/cz/fi/muni/pa165/entity/Journey.java
+++ b/fleet-management/src/main/java/cz/fi/muni/pa165/entity/Journey.java
@@ -29,9 +29,10 @@ public class Journey {
     private Employee employee;
 
     /**
-     * Initialize new Journey object. For serialization uses.
+     * All persistent classes must have a default constructor (which can be non-public)
+     * so that Hibernate can instantiate them using Constructor.newInstance().
      */
-    public Journey() {
+    protected Journey() {
     }
 
     /**

--- a/fleet-management/src/main/java/cz/fi/muni/pa165/entity/Vehicle.java
+++ b/fleet-management/src/main/java/cz/fi/muni/pa165/entity/Vehicle.java
@@ -44,9 +44,10 @@ public class Vehicle {
     private VehicleCategory vehicleCategory;
 
     /**
-     * Initialize new Vehicle object. For serialization uses.
+     * All persistent classes must have a default constructor (which can be non-public)
+     * so that Hibernate can instantiate them using Constructor.newInstance().
      */
-    public Vehicle() {
+    protected Vehicle() {
     }
 
     /**

--- a/fleet-management/src/main/java/cz/fi/muni/pa165/entity/Vehicle.java
+++ b/fleet-management/src/main/java/cz/fi/muni/pa165/entity/Vehicle.java
@@ -34,34 +34,6 @@ public class Vehicle {
     @Column(nullable = false, unique = true)
     private String vin;
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || (!(o instanceof Vehicle))) return false;
-
-        Vehicle vehicle = (Vehicle) o;
-
-        if (vrp != null ? !vrp.equals(vehicle.getVrp()) : vehicle.getVrp()!= null) return false;
-        if (type != null ? !type.equals(vehicle.getType()) : vehicle.getType() != null) return false;
-        if (productionYear != null ? !productionYear.equals(vehicle.getProductionYear()) : vehicle.getProductionYear()!= null)
-            return false;
-        if (engineType != null ? !engineType.equals(vehicle.getEngineType()) : vehicle.getEngineType()!= null) return false;
-        if (vin != null ? !vin.equals(vehicle.getVin()) : vehicle.getVin()!= null) return false;
-        return initialKilometrage != null ? initialKilometrage.equals(vehicle.getInitialKilometrage()) : vehicle.getInitialKilometrage()== null;
-
-    }
-
-    @Override
-    public int hashCode() {
-        int result = vrp != null ? vrp.hashCode() : 0;
-        result = 31 * result + (type != null ? type.hashCode() : 0);
-        result = 31 * result + (productionYear != null ? productionYear.hashCode() : 0);
-        result = 31 * result + (engineType != null ? engineType.hashCode() : 0);
-        result = 31 * result + (vin != null ? vin.hashCode() : 0);
-        result = 31 * result + (initialKilometrage != null ? initialKilometrage.hashCode() : 0);
-        return result;
-    }
-
     /**
      * Number od driven kilometres when car was added to the catalogue.
      */
@@ -70,6 +42,12 @@ public class Vehicle {
 
     @ManyToOne
     private VehicleCategory vehicleCategory;
+
+    /**
+     * Initialize new Vehicle object. For serialization uses.
+     */
+    public Vehicle() {
+    }
 
     /**
      * @param vrp                Vehicle VRP.
@@ -153,6 +131,34 @@ public class Vehicle {
 
     public void setInitialKilometrage(Long initialKilometrage) {
         this.initialKilometrage = initialKilometrage;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || (!(o instanceof Vehicle))) return false;
+
+        Vehicle vehicle = (Vehicle) o;
+
+        if (vrp != null ? !vrp.equals(vehicle.getVrp()) : vehicle.getVrp()!= null) return false;
+        if (type != null ? !type.equals(vehicle.getType()) : vehicle.getType() != null) return false;
+        if (productionYear != null ? !productionYear.equals(vehicle.getProductionYear()) : vehicle.getProductionYear()!= null)
+            return false;
+        if (engineType != null ? !engineType.equals(vehicle.getEngineType()) : vehicle.getEngineType()!= null) return false;
+        if (vin != null ? !vin.equals(vehicle.getVin()) : vehicle.getVin()!= null) return false;
+        return initialKilometrage != null ? initialKilometrage.equals(vehicle.getInitialKilometrage()) : vehicle.getInitialKilometrage()== null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = vrp != null ? vrp.hashCode() : 0;
+        result = 31 * result + (type != null ? type.hashCode() : 0);
+        result = 31 * result + (productionYear != null ? productionYear.hashCode() : 0);
+        result = 31 * result + (engineType != null ? engineType.hashCode() : 0);
+        result = 31 * result + (vin != null ? vin.hashCode() : 0);
+        result = 31 * result + (initialKilometrage != null ? initialKilometrage.hashCode() : 0);
+        return result;
     }
 
     @Override

--- a/fleet-management/src/main/java/cz/fi/muni/pa165/entity/Vehicle.java
+++ b/fleet-management/src/main/java/cz/fi/muni/pa165/entity/Vehicle.java
@@ -34,6 +34,34 @@ public class Vehicle {
     @Column(nullable = false, unique = true)
     private String vin;
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || (!(o instanceof Vehicle))) return false;
+
+        Vehicle vehicle = (Vehicle) o;
+
+        if (vrp != null ? !vrp.equals(vehicle.getVrp()) : vehicle.getVrp()!= null) return false;
+        if (type != null ? !type.equals(vehicle.getType()) : vehicle.getType() != null) return false;
+        if (productionYear != null ? !productionYear.equals(vehicle.getProductionYear()) : vehicle.getProductionYear()!= null)
+            return false;
+        if (engineType != null ? !engineType.equals(vehicle.getEngineType()) : vehicle.getEngineType()!= null) return false;
+        if (vin != null ? !vin.equals(vehicle.getVin()) : vehicle.getVin()!= null) return false;
+        return initialKilometrage != null ? initialKilometrage.equals(vehicle.getInitialKilometrage()) : vehicle.getInitialKilometrage()== null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = vrp != null ? vrp.hashCode() : 0;
+        result = 31 * result + (type != null ? type.hashCode() : 0);
+        result = 31 * result + (productionYear != null ? productionYear.hashCode() : 0);
+        result = 31 * result + (engineType != null ? engineType.hashCode() : 0);
+        result = 31 * result + (vin != null ? vin.hashCode() : 0);
+        result = 31 * result + (initialKilometrage != null ? initialKilometrage.hashCode() : 0);
+        return result;
+    }
+
     /**
      * Number od driven kilometres when car was added to the catalogue.
      */
@@ -125,22 +153,6 @@ public class Vehicle {
 
     public void setInitialKilometrage(Long initialKilometrage) {
         this.initialKilometrage = initialKilometrage;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        Vehicle vehicle = (Vehicle) o;
-
-        return id != null ? id.equals(vehicle.id) : vehicle.id == null;
-
-    }
-
-    @Override
-    public int hashCode() {
-        return id != null ? id.hashCode() : 0;
     }
 
     @Override

--- a/fleet-management/src/main/java/cz/fi/muni/pa165/entity/VehicleCategory.java
+++ b/fleet-management/src/main/java/cz/fi/muni/pa165/entity/VehicleCategory.java
@@ -23,9 +23,10 @@ public class VehicleCategory {
     private Set<Vehicle> vehicles = new HashSet<>();
 
     /**
-     * Initialize new VehicleCategory object. For serialization uses.
+     * All persistent classes must have a default constructor (which can be non-public)
+     * so that Hibernate can instantiate them using Constructor.newInstance().
      */
-    public VehicleCategory() {
+    protected VehicleCategory() {
     }
 
     /**

--- a/fleet-management/src/main/java/cz/fi/muni/pa165/entity/VehicleCategory.java
+++ b/fleet-management/src/main/java/cz/fi/muni/pa165/entity/VehicleCategory.java
@@ -22,28 +22,25 @@ public class VehicleCategory {
     @OneToMany(mappedBy = "vehicleCategory")
     private Set<Vehicle> vehicles = new HashSet<>();
 
+    /**
+     * Initialize new VehicleCategory object. For serialization uses.
+     */
+    public VehicleCategory() {
+    }
+
+    /**
+     * @param name name of the VehicleCategory
+     */
+    public VehicleCategory(String name) {
+        this.name = name;
+    }
+
     public Long getId() {
         return id;
     }
 
     public void setId(Long id) {
         this.id = id;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || (!(o instanceof VehicleCategory))) return false;
-
-        VehicleCategory that = (VehicleCategory) o;
-
-        return name != null ? name.equals(that.getName()) : that.getName() == null;
-
-    }
-
-    @Override
-    public int hashCode() {
-        return name != null ? name.hashCode() : 0;
     }
 
     public String getName() {
@@ -66,6 +63,21 @@ public class VehicleCategory {
         vehicles.add(vehicle);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || (!(o instanceof VehicleCategory))) return false;
+
+        VehicleCategory that = (VehicleCategory) o;
+
+        return name != null ? name.equals(that.getName()) : that.getName() == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        return name != null ? name.hashCode() : 0;
+    }
 
     @Override
     public String toString() {

--- a/fleet-management/src/main/java/cz/fi/muni/pa165/entity/VehicleCategory.java
+++ b/fleet-management/src/main/java/cz/fi/muni/pa165/entity/VehicleCategory.java
@@ -30,6 +30,22 @@ public class VehicleCategory {
         this.id = id;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || (!(o instanceof VehicleCategory))) return false;
+
+        VehicleCategory that = (VehicleCategory) o;
+
+        return name != null ? name.equals(that.getName()) : that.getName() == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        return name != null ? name.hashCode() : 0;
+    }
+
     public String getName() {
         return name;
     }
@@ -50,22 +66,6 @@ public class VehicleCategory {
         vehicles.add(vehicle);
     }
 
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        VehicleCategory that = (VehicleCategory) o;
-
-        return id != null ? id.equals(that.id) : that.id == null;
-
-    }
-
-    @Override
-    public int hashCode() {
-        return id != null ? id.hashCode() : 0;
-    }
 
     @Override
     public String toString() {

--- a/fleet-management/src/test/java/cz/fi/muni/pa165/dao/VehicleCategoryDaoImplTest.java
+++ b/fleet-management/src/test/java/cz/fi/muni/pa165/dao/VehicleCategoryDaoImplTest.java
@@ -35,12 +35,10 @@ public class VehicleCategoryDaoImplTest extends AbstractTransactionalTestNGSprin
 
     @BeforeMethod
     public void setUp() {
-        vehicleCategory1 = new VehicleCategory();
-        vehicleCategory1.setName("Supply");
+        vehicleCategory1 = new VehicleCategory("Supply");
         vehicleCategoryDao.persist(vehicleCategory1);
 
-        vehicleCategory2 = new VehicleCategory();
-        vehicleCategory2.setName("Representational");
+        vehicleCategory2 = new VehicleCategory("Representational");
         vehicleCategoryDao.persist(vehicleCategory2);
     }
 
@@ -69,8 +67,7 @@ public class VehicleCategoryDaoImplTest extends AbstractTransactionalTestNGSprin
         int itemCountBefore = vehicleCategoryDao.findAll().size();
 
         // Act
-        VehicleCategory vehicleCategory = new VehicleCategory();
-        vehicleCategory.setName("Facility Department");
+        VehicleCategory vehicleCategory = new VehicleCategory("Facility Department");
         vehicleCategoryDao.persist(vehicleCategory);
 
         // Assert


### PR DESCRIPTION
I refactor methods equals and hashcode,
-use business key instead of Id
-use instanceof instead of getClass()
-use getters on "other object" instead of taking advantages of visibility of other object's private field that IDE automatically generate.
-add missing no-arg constructor in some entities